### PR TITLE
Cause CI failure in case of rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,5 @@ jobs:
 
     - name: Build documentation
       run: cargo doc --verbose --all-features --no-deps --document-private-items
+      env: 
+        RUSTDOCFLAGS: "-Dwarnings"


### PR DESCRIPTION
Currently rustdoc warnings [don't cause the CI to fail](https://github.com/PaulDance/cargo-liner/actions/runs/5255360670/jobs/9495172600)

Sample failure: https://github.com/MaeIsBad/cargo-liner/actions/runs/5255463647/jobs/9495416222