### PR TITLE
Ensure there is a non-zero exit code when the programme errors

### DIFF
--- a/src/config/cargo_crates_toml.rs
+++ b/src/config/cargo_crates_toml.rs
@@ -19,7 +19,7 @@ pub struct CargoCratesToml {
 
 impl CargoCratesToml {
     /// The default name for the save file in Cargo's home.
-    pub const FILE_NAME: &str = ".crates.toml";
+    pub const FILE_NAME: &'static str = ".crates.toml";
 
     /// Returns the [`PathBuf`] pointing to the associated save file.
     ///

--- a/src/config/user_config.rs
+++ b/src/config/user_config.rs
@@ -19,7 +19,7 @@ pub struct UserConfig {
 
 impl UserConfig {
     /// The default name for the configuration file in Cargo's home.
-    pub const FILE_NAME: &str = "liner.toml";
+    pub const FILE_NAME: &'static str = "liner.toml";
 
     /// Returns the [`PathBuf`] pointing to the associated configuration file.
     pub fn file_path() -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,13 @@ use config::{CargoCratesToml, Package, UserConfig};
 
 /// Wrap the desired main and display errors in a fashion consistent with the
 /// rest of the messages.
-fn main() {
-    if let Err(err) = wrapped_main() {
-        error!("{}", err);
-        std::process::exit(1);
+fn main() -> std::process::ExitCode {
+    match wrapped_main() {
+        Ok(_) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            error!("{}", err);
+            std::process::ExitCode::FAILURE
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use config::{CargoCratesToml, Package, UserConfig};
 fn main() {
     if let Err(err) = wrapped_main() {
         error!("{}", err);
+        std::process::exit(1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //! and execution of `cargo install` with the required settings.
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
+use std::process::ExitCode;
 
 use anyhow::{bail, Result};
 #[macro_use]
@@ -17,12 +18,12 @@ use config::{CargoCratesToml, Package, UserConfig};
 
 /// Wrap the desired main and display errors in a fashion consistent with the
 /// rest of the messages.
-fn main() -> std::process::ExitCode {
+fn main() -> ExitCode {
     match wrapped_main() {
-        Ok(_) => std::process::ExitCode::SUCCESS,
+        Ok(_) => ExitCode::SUCCESS,
         Err(err) => {
             error!("{}", err);
-            std::process::ExitCode::FAILURE
+            ExitCode::FAILURE
         }
     }
 }


### PR DESCRIPTION
Currently if cargo liner fails in CI it can fail silently since its exit code on success or failure is zero. This PR updates the behaviour to have a non-zero exit code on failure.