### PR TITLE
Make sure to disable color in cargo output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "cargo-liner"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-liner"
 version = "0.4.2"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.70"
 description = """
 Cargo subcommand to install and update binary packages listed in configuration.
 """

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -96,7 +96,7 @@ fn spawn_search_exact(pkg: &str) -> Result<Child> {
     cmd.stdin(Stdio::null());
     cmd.stderr(Stdio::null());
     cmd.stdout(Stdio::piped());
-    cmd.args(["search", "--limit=1", "--", pkg]);
+    cmd.args(["search", "--color", "never", "--limit=1", "--", pkg]);
 
     log_cmd(&cmd);
     Ok(cmd.spawn()?)
@@ -158,6 +158,8 @@ pub fn config_get(key: &str) -> Result<String> {
     // FIXME: remove when `config` gets stabilized.
     cmd.env("RUSTC_BOOTSTRAP", "1");
     cmd.args([
+        "--color",
+        "never",
         "-Z",
         "unstable-options",
         "config",


### PR DESCRIPTION
This makes sure that `cargo` produces no color in its output, otherwise when `CARGO_TERM_COLOR` environment variable is set to `always` it messes up the version matching, e.g.:
```
TRACE cargo_liner::cargo                     > Search for "cargo-audit" got: "\u{1b}[1m\u{1b}[32mcargo-audit\u{1b}[0m = \"0.18.3\"    # Audit Cargo.lock for crates with security vulnerabilities\n... and 29 crates more (use --limit N to see more)\n"
ERROR cargo_liner                            > No regex capture while parsing search output for "cargo-audit": does the package exist?
```
I have also added it for `config get` subcommand just in case.

Additionally I have taken a liberty to downgrade the MSRV because the previous version (1.70.0) works just fine and the newest rust requirement introduces some problems into our CI.